### PR TITLE
Update Syntax to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,9 @@ documentation = "https://docs.rs/oursh"
 homepage = "https://nixpulvis/oursh/oursh"
 repository = "https://github.com/nixpulvis/oursh"
 
+# Get with the times.
+edition = "2018"
+
 # Compile our parser grammars.
 build = "build.rs"
 

--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -1,37 +1,36 @@
-#![feature(test)]
+#[macro_use]
+extern crate criterion;
 
-extern crate test;
-
-use std::process::Command;
-use test::Bencher;
+use criterion::Criterion;
 
 #[path="../tests/common/mod.rs"]
 mod common;
 
-#[bench]
-fn oursh_script(b: &mut Bencher) {
-    b.iter(|| {
-        oursh_release!(> "scripts/hello_world.sh");
-    })
+fn compare_benchmark(c: &mut Criterion) {
+    c.bench_function("oursh_script", |b| {
+        b.iter(|| {
+            oursh_release!(> "scripts/hello_world.sh");
+        })
+    });
+
+    c.bench_function("sh_script", |b| {
+        b.iter(|| {
+            shell!(> "/bin/sh", "scripts/hello_world.sh")
+        })
+    });
+
+    c.bench_function("zsh_script", |b| {
+        b.iter(|| {
+            shell!(> "/usr/bin/zsh", "scripts/hello_world.sh")
+        })
+    });
+
+    c.bench_function("fish_script", |b| {
+        b.iter(|| {
+            shell!(> "/usr/bin/fish", "scripts/hello_world.sh")
+        })
+    });
 }
 
-#[bench]
-fn sh_script(b: &mut Bencher) {
-    b.iter(|| {
-        shell!(> "/bin/sh", "scripts/hello_world.sh")
-    })
-}
-
-#[bench]
-fn zsh_script(b: &mut Bencher) {
-    b.iter(|| {
-        shell!(> "/usr/bin/zsh", "scripts/hello_world.sh")
-    })
-}
-
-#[bench]
-fn fish_script(b: &mut Bencher) {
-    b.iter(|| {
-        shell!(> "/usr/bin/fish", "scripts/hello_world.sh")
-    })
-}
+criterion_group!(benches, compare_benchmark);
+criterion_main!(benches);

--- a/benches/piped.rs
+++ b/benches/piped.rs
@@ -1,7 +1,6 @@
 #[macro_use]
 extern crate criterion;
 
-// use std::process::Command;
 use criterion::Criterion;
 
 #[path="../tests/common/mod.rs"]

--- a/src/job.rs
+++ b/src/job.rs
@@ -3,10 +3,14 @@
 //! All commands (both foreground and background) are created and executed as
 //! a *job*. This helps manage the commands the shell runs.
 
-use std::process::exit;
-use std::ffi::CString;
-use nix::unistd::{self, execvp, Pid, ForkResult};
-use nix::sys::wait::{waitpid, WaitStatus};
+use std::{
+    process::exit,
+    ffi::CString,
+};
+use nix::{
+    unistd::{self, execvp, Pid, ForkResult},
+    sys::wait::{waitpid, WaitStatus},
+};
 
 /// A job to be executed by various means.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,6 @@ use std::{
     io::{self, Read},
 };
 use docopt::{Docopt, ArgvMap, Value};
-use nix::sys::wait::WaitStatus;
 use termion::is_tty;
 use oursh::{
     repl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,14 +5,19 @@ extern crate nix;
 extern crate oursh;
 extern crate termion;
 
-use std::{env, process};
-use std::io::{self, Read};
-use std::fs::File;
+use std::{
+    env,
+    process,
+    fs::File,
+    io::{self, Read},
+};
 use docopt::{Docopt, ArgvMap, Value};
 use nix::sys::wait::WaitStatus;
 use termion::is_tty;
-use oursh::program::{Result, Error, Program, parse_primary};
-use oursh::repl;
+use oursh::{
+    repl,
+    program::{Result, Error, Program, parse_primary},
+};
 
 // Write the Docopt usage string.
 const USAGE: &'static str = "

--- a/src/program/basic.rs
+++ b/src/program/basic.rs
@@ -1,9 +1,13 @@
 //! Single command programs with no features.
-use std::io::BufRead;
-use std::ffi::CString;
+use std::{
+    io::BufRead,
+    ffi::CString,
+};
 use nix::sys::wait::WaitStatus;
-use job::Job;
-use program::{Result, Error};
+use crate::{
+    job::Job,
+    program::{Result, Error},
+};
 
 
 /// A basic program with only a single command.

--- a/src/program/mod.rs
+++ b/src/program/mod.rs
@@ -58,12 +58,16 @@
 //! - TODO #5: Parse sequence of programs from stream.
 //! - TODO #5: Partial parses for readline-ish / syntax highlighting.
 
-use std::ffi::CString;
-use std::fmt::Debug;
-use std::io::BufRead;
-use std::result;
-use nix::unistd::Pid;
-use nix::sys::wait::WaitStatus;
+use std::{
+    result,
+    ffi::CString,
+    fmt::Debug,
+    io::BufRead,
+};
+use nix::{
+    unistd::Pid,
+    sys::wait::WaitStatus,
+};
 
 /// Convenience type for results with program errors.
 pub type Result<T> = result::Result<T, Error>;

--- a/src/program/posix/ast.rs
+++ b/src/program/posix/ast.rs
@@ -155,8 +155,10 @@ impl Program {
 #[cfg(test)]
 mod tests {
     use lalrpop_util::ParseError;
-    use program::posix::parse::{ProgramParser, CommandParser};
-    use program::posix::lex::{Lexer, Token, Error};
+    use crate::program::posix::{
+        parse::{ProgramParser, CommandParser},
+        lex::{Lexer, Token, Error},
+    };
     use super::*;
 
     fn parse_program<'a>(text: &'a str)

--- a/src/program/posix/builtin.rs
+++ b/src/program/posix/builtin.rs
@@ -3,11 +3,16 @@
 //!
 //! These commands take precedence over any executables with the same name
 //! in the `$PATH`.
-use std::ffi::CString;
-use std::{env, process};
-use nix::unistd::{chdir, Pid};
-use nix::sys::wait::WaitStatus;
-use program::{Result, Error};
+use std::{
+    env,
+    process,
+    ffi::CString,
+};
+use nix::{
+    unistd::{chdir, Pid},
+    sys::wait::WaitStatus,
+};
+use crate::program::{Result, Error};
 
 /// A builtin is a custom shell command, often changing the state of the
 /// shell in some way.

--- a/src/program/posix/mod.lalrpop
+++ b/src/program/posix/mod.lalrpop
@@ -1,5 +1,4 @@
-use program::posix::ast;
-use program::posix::lex;
+use crate::program::posix::{ast, lex};
 
 grammar<'input>(text: &'input str);
 

--- a/src/program/posix/mod.rs
+++ b/src/program/posix/mod.rs
@@ -271,7 +271,7 @@ impl super::Command for Command {
             Command::Pipeline(ref left, ref right) => {
                 // TODO: This is obviously a temporary hack.
                 if let box Command::Simple(left_words) = left {
-                    let mut child = process::Command::new(&left_words[0].0)
+                    let child = process::Command::new(&left_words[0].0)
                         .args(left_words.iter().skip(1).map(|w| &w.0))
                         .stdout(Stdio::piped())
                         .spawn()

--- a/src/program/posix/mod.rs
+++ b/src/program/posix/mod.rs
@@ -114,23 +114,28 @@
 //!
 //! [1]: http://pubs.opengroup.org/onlinepubs/9699919799/
 
-use std::ffi::CString;
-use std::io::{Write, BufRead};
-use std::process::{self, Stdio};
-use std::thread;
+use std::{
+    thread,
+    ffi::CString,
+    io::{Write, BufRead},
+    process::{self, Stdio},
+};
 use lalrpop_util::ParseError;
-use nix::sys::wait::WaitStatus;
-use nix::unistd::Pid;
-use job::Job;
-use program::{Result, Error, Program as ProgramTrait};
+use nix::{
+    sys::wait::WaitStatus,
+    unistd::Pid,
+};
+use crate::{
+    job::Job,
+    program::{Result, Error, Program as ProgramTrait},
+};
 
 #[cfg(feature = "shebang-block")]
-use std::fs::{self, File};
-#[cfg(feature = "shebang-block")]
-use std::os::unix::fs::PermissionsExt;
-#[cfg(feature = "shebang-block")]
-use self::ast::Interpreter;
-
+use {
+    std::fs::{self, File},
+    std::os::unix::fs::PermissionsExt,
+    self::ast::Interpreter,
+};
 
 // Re-exports.
 pub use self::ast::Program;

--- a/src/repl/completion.rs
+++ b/src/repl/completion.rs
@@ -16,9 +16,12 @@
 //! assert_eq!("cargo", &text);
 //! ```
 
-use std::cmp::Ordering::Equal;
-use std::os::unix::fs::PermissionsExt;
-use std::{env, fs};
+use std::{
+    env,
+    fs,
+    cmp::Ordering::Equal,
+    os::unix::fs::PermissionsExt,
+};
 
 /// The result of a query for text completion.
 ///

--- a/src/repl/history.rs
+++ b/src/repl/history.rs
@@ -1,8 +1,10 @@
 //! Keeps a record of previous commands, used for completion and archeology.
-use std::fs::File;
-use std::path::Path;
-use std::io::prelude::*;
-use std::env;
+use std::{
+    env,
+    io::prelude::*,
+    fs::File,
+    path::Path,
+};
 
 /// The history of a user's provided commands.
 #[derive(Debug)]

--- a/src/repl/mod.rs
+++ b/src/repl/mod.rs
@@ -7,23 +7,25 @@ use std::io::{Write, Stdin, Stdout};
 use nix::unistd;
 use pwd::Passwd;
 use termion::{style, color};
-use program::Result;
+use crate::program::Result;
+
+#[cfg(feature = "raw")]
+use {
+    std::process::exit,
+    termion::cursor::DetectCursorPos,
+    termion::event::Key,
+    termion::input::TermRead,
+    termion::raw::IntoRawMode,
+};
+
 #[cfg(not(feature = "raw"))]
 use std::io::BufRead;
-#[cfg(feature = "raw")]
-use std::process::exit;
-#[cfg(feature = "raw")]
-use termion::cursor::DetectCursorPos;
-#[cfg(feature = "raw")]
-use termion::event::Key;
-#[cfg(feature = "raw")]
-use termion::input::TermRead;
-#[cfg(feature = "raw")]
-use termion::raw::IntoRawMode;
+
 #[cfg(feature = "completion")]
-use repl::completion::*;
+use self::completion::*;
+
 #[cfg(feature = "history")]
-use repl::history::History;
+use self::history::History;
 
 /// Start a REPL over the strings the user provides.
 // TODO: Partial syntax, completion.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -26,7 +26,7 @@ macro_rules! shell {
     (> $executable:expr, $filename:expr) => {{
         use std::process::{Command, Stdio};
 
-        let mut child = Command::new($executable)
+        let child = Command::new($executable)
             .arg($filename)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())


### PR DESCRIPTION
Update use statements to use the new nested blocks. Also fixes a few warnings.

fixes #39