### PR TITLE
Comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2021-08-10
           components: clippy
       - uses: actions-rs/cargo@v1
         with:

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2021-07-11-x86_64-unknown-linux-gnu

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2021-07-11-x86_64-unknown-linux-gnu
+nightly-2021-08-10

--- a/src/program/posix/lex.rs
+++ b/src/program/posix/lex.rs
@@ -132,7 +132,7 @@ impl<'input> Iterator for Lexer<'input> {
                 '\n' => Some(Ok((s, Token::Linefeed, e))),
                 ';'  => Some(Ok((s, Token::Semi, e))),
                 '#'  => {
-                    while let Some((s, c, e)) = self.lookahead {
+                    while let Some((_, c, _)) = self.lookahead {
                         match c {
                             '\n' => break,
                             _ => self.advance(),
@@ -515,6 +515,13 @@ mod tests {
                         Some(Ok((_, Token::Linefeed, _))));
         assert_matches!(lexer.next(),
                         Some(Ok((_, Token::Word("word2"), _))));
+        assert!(lexer.next().is_none());
+
+        let mut lexer = Lexer::new("#word");
+        assert!(lexer.next().is_none());
+        let mut lexer = Lexer::new("word#word");
+        assert_matches!(lexer.next(),
+                        Some(Ok((_, Token::Word("word#word"), _))));
         assert!(lexer.next().is_none());
     }
 }

--- a/src/program/posix/lex.rs
+++ b/src/program/posix/lex.rs
@@ -131,6 +131,15 @@ impl<'input> Iterator for Lexer<'input> {
             let tok = match c {
                 '\n' => Some(Ok((s, Token::Linefeed, e))),
                 ';'  => Some(Ok((s, Token::Semi, e))),
+                '#'  => {
+                    while let Some((s, c, e)) = self.advance() {
+                        match c {
+                            '\n' => break,
+                            _ => {},
+                        }
+                    }
+                    self.next()
+                }
                 ')'  => Some(Ok((s, Token::RParen, e))),
                 '('  => Some(Ok((s, Token::LParen, e))),
                 '`'  => Some(Ok((s, Token::Backtick, e))),

--- a/src/program/posix/lex.rs
+++ b/src/program/posix/lex.rs
@@ -524,4 +524,11 @@ mod tests {
                         Some(Ok((_, Token::Word("word#word"), _))));
         assert!(lexer.next().is_none());
     }
+
+    #[test]
+    #[ignore]
+    fn backtick_comment_undefined_behaviour() {
+        let mut lexer = Lexer::new("\"`echo #`\"");
+        // TODO: Read section 6: Word expansion, we need new AST types.
+    }
 }

--- a/src/program/posix/lex.rs
+++ b/src/program/posix/lex.rs
@@ -132,11 +132,11 @@ impl<'input> Iterator for Lexer<'input> {
                 '\n' => Some(Ok((s, Token::Linefeed, e))),
                 ';'  => Some(Ok((s, Token::Semi, e))),
                 '#'  => {
-                    while let Some((s, c, e)) = self.advance() {
+                    while let Some((s, c, e)) = self.lookahead {
                         match c {
                             '\n' => break,
-                            _ => {},
-                        }
+                            _ => self.advance(),
+                        };
                     }
                     self.next()
                 }
@@ -499,5 +499,22 @@ mod tests {
                         Some(Ok((_, Token::Word("ls"), _))));
         assert_matches!(lexer.next(),
                         Some(Ok((_, Token::Done, _))));
+    }
+
+    #[test]
+    fn comments() {
+        let mut lexer = Lexer::new("word # comment");
+        assert_matches!(lexer.next(),
+                        Some(Ok((_, Token::Word("word"), _))));
+        assert!(lexer.next().is_none());
+
+        let mut lexer = Lexer::new("word1 # comment1\nword2 # comment2");
+        assert_matches!(lexer.next(),
+                        Some(Ok((_, Token::Word("word1"), _))));
+        assert_matches!(lexer.next(),
+                        Some(Ok((_, Token::Linefeed, _))));
+        assert_matches!(lexer.next(),
+                        Some(Ok((_, Token::Word("word2"), _))));
+        assert!(lexer.next().is_none());
     }
 }

--- a/src/program/posix/mod.rs
+++ b/src/program/posix/mod.rs
@@ -508,3 +508,16 @@ lalrpop_mod!(
     #[allow(unknown_lints)]
     /// LALRPOP generated parser module.
     pub parse, "/program/posix/mod.rs");
+
+#[cfg(test)]
+mod tests {
+    use crate::program::Program as ProgramTrait;
+    use super::*;
+
+    #[test]
+    fn program_parse_empty() {
+        let result: Result<Program> = Program::parse(b"" as &[u8]);
+        assert!(result.is_ok());
+        assert!(result.unwrap().0.is_empty());
+    }
+}

--- a/src/program/posix/mod.rs
+++ b/src/program/posix/mod.rs
@@ -181,9 +181,13 @@ impl super::Program for Program {
                         eprintln!("unexpected token {:?} found at {}-{}, expecting one of: {}",
                                   t, s, e, expected.join(", "));
                     },
-                    ParseError::UnrecognizedEOF { location, expected }=> {
-                        eprintln!("unexpected EOF found at {}, expecting one of: {}",
-                                  location, expected.join(", "));
+                    ParseError::UnrecognizedEOF { location, expected } => {
+                        if location == 0 {
+                            return Ok(Program(vec![]))
+                        } else {
+                            eprintln!("unexpected EOF found at {}, expecting one of: {}",
+                                      location, expected.join(", "));
+                        }
                     }
                     ParseError::ExtraToken { token: (i, t, _) } => {
                         eprintln!("extra token {:?} found at {}", t, i);


### PR DESCRIPTION
Ignore everything after a `#` symbol unless quoted or otherwise noted.

> If the current character is a `'#'`, it and all subsequent characters up to, but excluding, the next `<newline>` shall be discarded as a comment. The `<newline>` that ends the line is not considered part of the comment.

fixes #56